### PR TITLE
Update 'minio' version to resolve vulnerability in 'commons-compress' transitive dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [libraries]
 commons-text = { module = "org.apache.commons:commons-text", version = "1.9" }
-minio = { module = "io.minio:minio", version = "8.5.8" }
+minio = { module = "io.minio:minio", version = "8.5.9" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version = "5.10.2" }
 
 [plugins]


### PR DESCRIPTION
Bump the version of `io.minio:minio` to `8.5.9`, which in turn bumps the version of transitive dependnecy `org.apache.commons:commons-compress` to `1.26.0`.

This resolves a Dependabot alert caused by a CVE in `org.apache.common:commons-compress:1.24.0`.