### PR TITLE
Constrain 'commons-compress' transitive dependency to a non-vulnerable version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [libraries]
+commons-compress = { module = "org.apache.commons:commons-compress", version = "1.26.1" }
 commons-text = { module = "org.apache.commons:commons-text", version = "1.9" }
 minio = { module = "io.minio:minio", version = "8.5.8" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version = "5.10.2" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -10,6 +10,11 @@ dependencies {
     implementation(libs.commons.text)
     implementation(libs.minio)
 
+    constraints {
+        // Force a newer version of commons-compress in transitive resolution
+        implementation(libs.commons.compress)
+    }
+
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }


### PR DESCRIPTION
The 'io.minio:minio:8.5.8' library' has a dependency on a vulnerable version of 'org.apache.commons:commons-compress'.

Assuming there is no fixed version of the `minio` library available, we avoid this vulnerability using a dependency constraint that causes a newer version of 'commons-compress' to be used.