### PR TITLE
Update README with current screenshots and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In order to receive alerts about any vulnerable dependencies for this repository
 
 1. **Dependency graph and Dependabot alerts are enabled**
 
-<img width="800" alt="image" src="https://github.com/gradle/github-dependency-submission-demo/assets/179734/7ecf6cc6-aec2-4985-8331-b9e9db78d312">
+<img width="800" alt="image" src="https://github.com/user-attachments/assets/978e21bb-8082-4861-98a5-b42a41fa29a8" />
 
 2. **A simple `dependency-submission` workflow is configured to run on any push to the `main` branch**
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Note that all dependencies reported by the action will be tagged with <code>Dete
 After executing the `dependency-submission` workflow, the repository has 5 current Dependabot alerts for vulnerable dependencies. 
 These are not publicly visible in the repo, but here is the list:
 
-<img width="800" alt="image" src="https://github.com/gradle/github-dependency-submission-demo/assets/179734/1e9905c6-d1cf-40ea-bdc1-d42b70eafefe">
+<img width="800" alt="image" src="https://github.com/user-attachments/assets/99120685-bfd3-42c8-81cf-f750a041f7b8" />
 
 # Fixing dependency vulnerabilities
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You may find it useful to fork this repository, which will allow you to follow t
 Note that GitHub Actions workflows are not automatically enabled for repository forks. 
 To start the process, you'll need to:
 1. Fork the repository
-2. Navigate to "Settings -> Code security and analysis" to enable Dependency graph and Dependabot alerts (see below)
+2. Navigate to "Settings -> Advanced Security" and enable Dependency graph and Dependabot alerts (see below)
 3. Navigate to the "Actions" tab to enable GitHub Actions workflows
 4. Push a commit to the 'main' branch in order to trigger the initial `dependency-submission` workflow to run. A change to the README will be sufficient.
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ You can view all of these dependencies, and search for a particular dependency [
 
 Note that all dependencies reported by the action will be tagged with <code>Detected by **GitHub Dependency Graph Gradle Plugin**</code>.
 
-
 # Viewing vulnerabilities reported for this repository
 
-After executing the `dependency-submission` workflow, the repository has 5 current Dependabot alerts for vulnerable dependencies. 
+After executing the `dependency-submission` workflow, the repository has several current Dependabot alerts for vulnerable dependencies. 
 These are not publicly visible in the repo, but here is the list:
 
 <img width="800" alt="image" src="https://github.com/user-attachments/assets/99120685-bfd3-42c8-81cf-f750a041f7b8" />


### PR DESCRIPTION
Corrects the navigation path for enabling Dependency graph and Dependabot alerts, pointing to "Settings -> Advanced Security" instead of the previous location.

Corrects the count of vulnerabilities in the project and updates the screenshot of them.